### PR TITLE
Add layers.Dropout as another random seed to set

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ os.environ['PYTHONHASHSEED']=str(SEED)
 random.seed(SEED)
 np.random.seed(SEED)
 tf.random.set_seed(SEED)
+layer = layers.Dropout(rate, seed=SEED)
 ```
 
 #### Dataset Sharding ####


### PR DESCRIPTION
The `seed` param of the `layers.Dropout` is another source of non-determinism. It would be valuable to document this here.